### PR TITLE
Add support to common plugins - visual selection invert option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ vim.cmd.colorscheme("gruber-darker")
   bold = true,
   invert = {
     signs = false,
+    tabline = false,
+    visual = false,
   },
   italic = {
     strings = true,

--- a/lua/gruber-darker/config.lua
+++ b/lua/gruber-darker/config.lua
@@ -7,6 +7,7 @@
 ---@alias InvertType
 ---|"signs"
 ---|"tabline"
+---|"visual"
 
 ---@class GruberDarkerOpts
 ---@field bold boolean
@@ -21,6 +22,7 @@ local DEFAULTS = {
 	invert = {
 		signs = false,
 		tabline = false,
+		visual = false,
 	},
 	italic = {
 		strings = true,

--- a/lua/gruber-darker/highlights/cmp.lua
+++ b/lua/gruber-darker/highlights/cmp.lua
@@ -1,0 +1,52 @@
+local Highlight = require("gruber-darker.highlight")
+local c = require("gruber-darker.palette")
+local vim_hl = require("gruber-darker.highlights.vim").highlights
+local gruber_hl = require("gruber-darker.highlights.colorscheme").highlights
+
+---@type HighlightsProvider
+local M = {
+	highlights = {},
+}
+
+function M.setup()
+	for _, value in pairs(M.highlights) do
+		value:setup()
+	end
+end
+
+M.highlights.cmp_item_kind = Highlight.new("CmpItemKind", { fg = c.white })
+M.highlights.cmp_item_menu = Highlight.new("CmpItemMenu", { fg = c.white })
+M.highlights.cmp_item_deprecated = Highlight.new("CmpItemAbbrDeprecated", { link = gruber_hl.darkest_niagara })
+M.highlights.cmp_item_abbr = Highlight.new("CmpItemAbbr", { fg = c.white })
+M.highlights.cmp_item_abbr_match = Highlight.new("CmpItemAbbrMatch", { link = gruber_hl.yellow_bold })
+M.highlights.cmp_item_abbr_match_fuzzy = Highlight.new("CmpItemAbbrMatchFuzzy", { link = gruber_hl.brown_bold })
+M.highlights.cmp_item_kind_text = Highlight.new("CmpItemKindText", { fg = c["fg+2"] })
+M.highlights.cmp_item_kind_method = Highlight.new("CmpItemKindMethod", { link = vim_hl.func })
+M.highlights.cmp_item_kind_function = Highlight.new("CmpItemKindFunction", { link = vim_hl.func })
+M.highlights.cmp_item_kind_constructor =
+	Highlight.new("CmpItemKindConstructor", { link = vim_hl.func })
+M.highlights.cmp_item_kind_field = Highlight.new("CmpItemKindField", { link = gruber_hl.niagara })
+M.highlights.cmp_item_kind_variable = Highlight.new("CmpItemKindVariable", { link = vim_hl.identifier })
+M.highlights.cmp_item_kind_class = Highlight.new("CmpitemKindClass", { link = vim_hl.type })
+M.highlights.cmp_item_kind_interface = Highlight.new("CmpItemKindInterface", { link = vim_hl.type })
+M.highlights.cmp_item_kind_module = Highlight.new("CmpItemKindModule", { link = vim_hl.define })
+M.highlights.cmp_item_kind_property = Highlight.new("CmpItemKindProperty", { link = gruber_hl.dark_niagara })
+M.highlights.cmp_item_kind_unit = Highlight.new("CmpItemKindUnit", { link = gruber_hl.dark_niagara })
+M.highlights.cmp_item_kind_value = Highlight.new("CmpItemKindValue", { link = vim_hl.type })
+M.highlights.cmp_item_kind_enum = Highlight.new("CmpItemKindEnum", { link = vim_hl.type })
+M.highlights.cmp_item_kind_keywork = Highlight.new("CmpItemKindKeyword", { link = vim_hl.keyword })
+M.highlights.cmp_item_kind_snippet = Highlight.new("CmpItemKindSnippet", { link = gruber_hl.dark_niagara })
+M.highlights.cmp_item_kind_color = Highlight.new("CmpItemKindColor", { fg = c.yellow })
+M.highlights.cmp_item_kind_file = Highlight.new("CmpItemKindFile", { fg = c.wisteria })
+M.highlights.cmp_item_kind_reference = Highlight.new("CmpItemKindReference", { fg = c.wisteria })
+M.highlights.cmp_item_kind_folder = Highlight.new("CmpItemKindFolder", { fg = c.wisteria })
+M.highlights.cmp_item_kind_enum_member =
+	Highlight.new("CmpItemKindEnumMember", { link = vim_hl.type })
+M.highlights.cmp_item_kind_constant = Highlight.new("CmpItemKindConstant", { link = vim_hl.constant })
+M.highlights.cmp_item_kind_struct = Highlight.new("CmpItemKindStruct", { link = gruber_hl.niagara })
+M.highlights.cmp_item_kind_event = Highlight.new("CmpItemKindEvent", { fg = c.brown })
+M.highlights.cmp_item_kind_operator = Highlight.new("CmpItemKindOperator", { link = vim_hl.operator })
+M.highlights.cmp_item_kind_type_parameter =
+	Highlight.new("CmpItemKindTypeParameter", { link = vim_hl.identifier })
+
+return M

--- a/lua/gruber-darker/highlights/init.lua
+++ b/lua/gruber-darker/highlights/init.lua
@@ -11,6 +11,7 @@ local providers = {
 	require("gruber-darker.highlights.vim"),
 	require("gruber-darker.highlights.terminal"),
 	require("gruber-darker.highlights.treesitter"),
+	require("gruber-darker.highlights.cmp"),
 }
 
 ---Set highlights for configured providers

--- a/lua/gruber-darker/highlights/vim.lua
+++ b/lua/gruber-darker/highlights/vim.lua
@@ -145,7 +145,7 @@ M.highlights.tab_line_sel = Highlight.new("TabLineSel", { fg = c.yellow, bg = c.
 ---Titles for output from ":set all", ":autocmd" etc.
 M.highlights.title = Highlight.new("Title", { link = gruber_hl.quartz })
 ---Visual mode selection
-M.highlights.visual = Highlight.new("Visual", { bg = c["bg+2"] })
+M.highlights.visual = Highlight.new("Visual", { bg = c["bg+2"], reverse = opts.invert.visual })
 ---Visual mode selection when vim is "Not Owning the Selection".
 M.highlights.visual_nos = Highlight.new("VisualNOS", { link = gruber_hl.red })
 ---Warning messages

--- a/lua/gruber-darker/highlights/vim.lua
+++ b/lua/gruber-darker/highlights/vim.lua
@@ -42,6 +42,12 @@ M.highlights.diff_change = Highlight.new("DiffChange", { fg = c.yellow, bg = c.n
 M.highlights.diff_delete = Highlight.new("DiffDelete", { fg = c["red+1"], bg = c.none })
 ---Diff mode: Changed text within a changed line |diff.txt|
 M.highlights.diff_text = Highlight.new("DiffText", { fg = c.yellow, bg = c.none })
+
+---Fugitive highlights; might need separate provider for git related plugins
+M.highlights.diff_added = Highlight.new("diffAdded", { link = M.highlights.diff_add })
+M.highlights.diff_removed = Highlight.new("diffRemoved", { link = M.highlights.diff_delete })
+M.highlights.diff_line = Highlight.new("diffLine", { link = M.highlights.diff_change })
+
 ---Filler lines (~) after the end of the buffer.  By, this is highlighted like |hl-NonText|.
 M.highlights.end_of_buffer = Highlight.new("EndOfBuffer", { fg = c["bg+4"], bg = c.none })
 ---Cursor in a focused terminal


### PR DESCRIPTION
Hi, love your work so far.. I'm daily driving this colorscheme and I think It's ready to get some plugins support..

Added a separate provider for `nvim-cmp` support, and some basic highlights for `vim-fugitive`

Also, added option to let user invert (same as reverse) colors in visual mode/selection (I really love the result with this color palette, you definitely should try It)

Hope this helps!