### PR TITLE
Fix user config loading - add some plugins support

### DIFF
--- a/lua/gruber-darker.lua
+++ b/lua/gruber-darker.lua
@@ -1,5 +1,4 @@
 local config = require("gruber-darker.config")
-local highlights = require("gruber-darker.highlights")
 
 local M = {}
 
@@ -46,6 +45,8 @@ end
 
 ---Clear current highlights and set Neovim global `colors_name`
 function M.load()
+	local highlights = require("gruber-darker.highlights")
+
 	if vim.g.colors_name then
 		vim.cmd.hi("clear")
 	end

--- a/lua/gruber-darker/highlights/init.lua
+++ b/lua/gruber-darker/highlights/init.lua
@@ -12,6 +12,7 @@ local providers = {
 	require("gruber-darker.highlights.terminal"),
 	require("gruber-darker.highlights.treesitter"),
 	require("gruber-darker.highlights.cmp"),
+	require("gruber-darker.highlights.telescope"),
 }
 
 ---Set highlights for configured providers

--- a/lua/gruber-darker/highlights/lsp.lua
+++ b/lua/gruber-darker/highlights/lsp.lua
@@ -33,8 +33,8 @@ M.highlights.diagnostic_underline_hint =
 M.highlights.diagnostic_unnecessary = Highlight.new("DiagnosticUnnecessary", { link = M.highlights.diagnostic_underline_hint })
 
 ---LspSaga floating windows
-M.highlights.saga_normal = Highlight.new("SagaNormal", { link = M.highlights.normal_float })
-M.highlights.saga_border = Highlight.new("SagaBorder", { link = M.highlights.float_border })
+M.highlights.saga_normal = Highlight.new("SagaNormal", { link = vim_hl.normal_float })
+M.highlights.saga_border = Highlight.new("SagaBorder", { link = vim_hl.float_border })
 
 ---Used for highlighting "text" references
 -- M.highlights.lsp_reference_text = Highlight.new("LspReferenceText", {})

--- a/lua/gruber-darker/highlights/lsp.lua
+++ b/lua/gruber-darker/highlights/lsp.lua
@@ -32,6 +32,10 @@ M.highlights.diagnostic_underline_hint =
 
 M.highlights.diagnostic_unnecessary = Highlight.new("DiagnosticUnnecessary", { link = M.highlights.diagnostic_underline_hint })
 
+---LspSaga floating windows
+M.highlights.saga_normal = Highlight.new("SagaNormal", { link = M.highlights.normal_float })
+M.highlights.saga_border = Highlight.new("SagaBorder", { link = M.highlights.float_border })
+
 ---Used for highlighting "text" references
 -- M.highlights.lsp_reference_text = Highlight.new("LspReferenceText", {})
 ---Used for highlighting "read" references

--- a/lua/gruber-darker/highlights/telescope.lua
+++ b/lua/gruber-darker/highlights/telescope.lua
@@ -1,0 +1,26 @@
+local Highlight = require("gruber-darker.highlight")
+local c = require("gruber-darker.palette")
+local vim_hl = require("gruber-darker.highlights.vim").highlights
+local gruber_hl = require("gruber-darker.highlights.colorscheme").highlights
+
+---@type HighlightsProvider
+local M = {
+	highlights = {},
+}
+
+function M.setup()
+	for _, value in pairs(M.highlights) do
+		value:setup()
+	end
+end
+
+M.highlights.telescope_normal = Highlight.new("TelescopeNormal", { link = gruber_hl.fg })
+M.highlights.telescope_matching = Highlight.new("TelescopeMatching", { link = gruber_hl.yellow_bold })
+M.highlights.telescope_border = Highlight.new("TelescopeBorder", { link = vim_hl.float_border })
+M.highlights.telescope_prompt_prefix = Highlight.new("TelescopePromptPrefix", { link = gruber_hl.niagara })
+M.highlights.telescope_title = Highlight.new("TelescopeTitle", { fg = c.white })
+M.highlights.telescope_selection = Highlight.new("TelescopeSelection", { fg = c["fg+2"], bg = c["bg+1"] })
+M.highlights.telescope_multi_selection = Highlight.new("TelescopeMultiSelection", { link = vim_hl.cursor_line })
+M.highlights.telescope_selection_caret = Highlight.new("TelescopeSelectionCaret", { link = gruber_hl.yellow })
+
+return M

--- a/lua/gruber-darker/highlights/vim.lua
+++ b/lua/gruber-darker/highlights/vim.lua
@@ -87,7 +87,7 @@ M.highlights.non_text = Highlight.new("NonText", { link = M.highlights.end_of_bu
 ---Normal text
 M.highlights.normal = Highlight.new("Normal", { fg = c.fg, bg = c.bg })
 ---Normal text in non-current windows
-M.highlights.normal_non_current = Highlight.new("NormalNC", { fg = c.fg, bg = c["bg-1"] })
+M.highlights.normal_non_current = Highlight.new("NormalNC", { fg = c.fg, bg = c.bg })
 ---Normal text in sidebar
 M.highlights.normal_sidebar = Highlight.new("NormalSB", { fg = c.fg, bg = c["bg-1"] })
 ---Normal text in floating windows.


### PR DESCRIPTION
Hi! Just noticed there was a very simple yet annoying bug that didn't let requiring modules in the correct order when calling `setup()` to override the default configuration.
Specifically, by moving `local highlights = require("gruber-darker.nvim.highlights")` line inside the `load()` function, I was able to prevent requiring all the providers (that also had nested requiring) **before** `setup()` function actually overrides user config

I added some basic support for `telescope.nvim` and `LspSaga`'s floating windows.

Also changed `NormalNC` to default background color because that looked weird to me for all `telescope` windows.