### PR TITLE
feat: add `GitSigns` highlight group

### DIFF
--- a/lua/gruber-darker/highlights/vim.lua
+++ b/lua/gruber-darker/highlights/vim.lua
@@ -48,6 +48,11 @@ M.highlights.diff_added = Highlight.new("diffAdded", { link = M.highlights.diff_
 M.highlights.diff_removed = Highlight.new("diffRemoved", { link = M.highlights.diff_delete })
 M.highlights.diff_line = Highlight.new("diffLine", { link = M.highlights.diff_change })
 
+---Gitsigns highlights
+M.highlights.git_signs_add = Highlight.new("GitSignsAdd", { link = M.highlights.diff_add })
+M.highlights.git_signs_change = Highlight.new("GitSignsChange", { link = M.highlights.diff_change })
+M.highlights.git_signs_delete = Highlight.new("GitSignsDelete", { link = M.highlights.diff_delete })
+
 ---Filler lines (~) after the end of the buffer.  By, this is highlighted like |hl-NonText|.
 M.highlights.end_of_buffer = Highlight.new("EndOfBuffer", { fg = c["bg+4"], bg = c.none })
 ---Cursor in a focused terminal


### PR DESCRIPTION
Hi! Been loving this project recently, and just wanted to add a change that fixes the [`gitsigns`](https://github.com/lewis6991/gitsigns.nvim) highlights. This PR adds specific `GitSigns` highlight groups. As when I was using the colorscheme, the gitsign highlights groups were not correctly falling back to `Diff` highlight groups - therefore, it was rendering the gitsigns using the default nvim colors and not with the gruber-darker colors.

Let me know if this works!