### PR TITLE
fix cursor blending with hlsearch

### DIFF
--- a/lua/gruber-darker/highlights/vim.lua
+++ b/lua/gruber-darker/highlights/vim.lua
@@ -118,7 +118,7 @@ M.highlights.quick_fix_line = Highlight.new("QuickFixLine", { bg = c["bg+2"], bo
 -- Search
 
 ---Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-M.highlights.search = Highlight.new("Search", { fg = c.black, bg = c.yellow })
+M.highlights.search = Highlight.new("Search", { fg = c["niagara-1"], bg = c["fg+1"] })
 ---'incsearch' highlighting; also used for the text replaced with ":s///c"
 M.highlights.incremental_search = Highlight.new("IncSearch", { fg = c.black, bg = c["fg+2"] })
 M.highlights.current_search = Highlight.new("CurSearch", { link = M.highlights.incremental_search })


### PR DESCRIPTION
Change `hl-Search` colors to make search matches visually distinct from the cursor. Now matches [rexim/gruber-darker-theme](https://github.com/rexim/gruber-darker-theme).