### PR TITLE
feat: Add support for compile-mode.nvim plugin

### DIFF
--- a/lua/gruber-darker/highlights/compile-mode.lua
+++ b/lua/gruber-darker/highlights/compile-mode.lua
@@ -1,6 +1,5 @@
 local Highlight = require("gruber-darker.highlight")
 local gruber_hl = require("gruber-darker.highlights.colorscheme").highlights
-local lsp_hl = require("gruber-darker.highlights.lsp").highlights
 
 ---@type HighlightsProvider
 local M = {
@@ -13,11 +12,18 @@ function M.setup()
 	end
 end
 
-M.highlights.compile_mode_command_output = Highlight.new("CompileModeCommandOutput", { link = lsp_hl.diagnostic_info })
-M.highlights.compile_mode_warning = Highlight.new("CompileModeWarning", { link = lsp_hl.diagnostic_warn })
-M.highlights.compile_mode_error = Highlight.new("CompileModeError", { link = lsp_hl.diagnostic_error })
-
+M.highlights.compile_mode_message = Highlight.new("CompileModeMessage", { link = gruber_hl.fg0 , underline=true})
 M.highlights.compile_mode_message_row = Highlight.new("CompileModeMessageRow", { link = gruber_hl.yellow })
 M.highlights.compile_mode_message_col = Highlight.new("CompileModeMessageCol", { link = gruber_hl.green })
+
+M.highlights.compile_mode_error = Highlight.new("CompileModeError", { link = gruber_hl.red })
+M.highlights.compile_mode_warning = Highlight.new("CompileModeWarning", { link = gruber_hl.brown })
+M.highlights.compile_mode_info = Highlight.new("CompileModeInfo", { link = gruber_hl.green })
+
+M.highlights.compile_mode_command_output = Highlight.new("CompileModeCommandOutput", { link = gruber_hl.niagara })
+M.highlights.compile_mode_directory_message = Highlight.new("CompileModeDirectoryMessage", { link = gruber_hl.niagara })
+M.highlights.compile_mode_directory_message = Highlight.new("CompileModeOutputFile", { link = gruber_hl.yellow_bold })
+M.highlights.compile_mode_directory_message = Highlight.new("CompileModeCheckResult", { link = gruber_hl.wisteria_bold })
+M.highlights.compile_mode_directory_message = Highlight.new("CompileModeCheckTarget", { link = gruber_hl.wisteria_bold })
 
 return M

--- a/lua/gruber-darker/highlights/compile-mode.lua
+++ b/lua/gruber-darker/highlights/compile-mode.lua
@@ -1,0 +1,23 @@
+local Highlight = require("gruber-darker.highlight")
+local gruber_hl = require("gruber-darker.highlights.colorscheme").highlights
+local lsp_hl = require("gruber-darker.highlights.lsp").highlights
+
+---@type HighlightsProvider
+local M = {
+	highlights = {},
+}
+
+function M.setup()
+	for _, value in pairs(M.highlights) do
+		value:setup()
+	end
+end
+
+M.highlights.compile_mode_command_output = Highlight.new("CompileModeCommandOutput", { link = lsp_hl.diagnostic_info })
+M.highlights.compile_mode_warning = Highlight.new("CompileModeWarning", { link = lsp_hl.diagnostic_warn })
+M.highlights.compile_mode_error = Highlight.new("CompileModeError", { link = lsp_hl.diagnostic_error })
+
+M.highlights.compile_mode_message_row = Highlight.new("CompileModeMessageRow", { link = gruber_hl.yellow })
+M.highlights.compile_mode_message_col = Highlight.new("CompileModeMessageCol", { link = gruber_hl.green })
+
+return M

--- a/lua/gruber-darker/highlights/compile-mode.lua
+++ b/lua/gruber-darker/highlights/compile-mode.lua
@@ -22,8 +22,8 @@ M.highlights.compile_mode_info = Highlight.new("CompileModeInfo", { link = grube
 
 M.highlights.compile_mode_command_output = Highlight.new("CompileModeCommandOutput", { link = gruber_hl.niagara })
 M.highlights.compile_mode_directory_message = Highlight.new("CompileModeDirectoryMessage", { link = gruber_hl.niagara })
-M.highlights.compile_mode_directory_message = Highlight.new("CompileModeOutputFile", { link = gruber_hl.yellow_bold })
-M.highlights.compile_mode_directory_message = Highlight.new("CompileModeCheckResult", { link = gruber_hl.wisteria_bold })
-M.highlights.compile_mode_directory_message = Highlight.new("CompileModeCheckTarget", { link = gruber_hl.wisteria_bold })
+M.highlights.compile_mode_output_file = Highlight.new("CompileModeOutputFile", { link = gruber_hl.yellow_bold })
+M.highlights.compile_mode_check_result = Highlight.new("CompileModeCheckResult", { link = gruber_hl.wisteria_bold })
+M.highlights.compile_mode_check_target = Highlight.new("CompileModeCheckTarget", { link = gruber_hl.wisteria_bold })
 
 return M

--- a/lua/gruber-darker/highlights/init.lua
+++ b/lua/gruber-darker/highlights/init.lua
@@ -14,6 +14,7 @@ local providers = {
 	require("gruber-darker.highlights.cmp"),
 	require("gruber-darker.highlights.telescope"),
 	require("gruber-darker.highlights.rainbow"),
+	require("gruber-darker.highlights.compile-mode"),
 }
 
 ---Set highlights for configured providers


### PR DESCRIPTION
Hi! This PR adds support for [compile-mode.nvim](https://github.com/ej-shafran/compile-mode.nvim) plugin.
Compile mode is pretty popular in emacs, where this colorsceme originates from, so I think it will be very nice to support a plugin that ports it to neovim.